### PR TITLE
Improve handling of non-200 response codes

### DIFF
--- a/django_medusa/renderers/appengine.py
+++ b/django_medusa/renderers/appengine.py
@@ -40,7 +40,10 @@ def _gae_render_path(args):
 
         resp = client.get(path)
         if resp.status_code != 200:
-            raise Exception
+            raise Exception(
+                "Request to %s produced response code %d" %
+                (path, resp.status_code)
+            )
 
         mimetype = resp['Content-Type'].split(";", 1)[0]
 

--- a/django_medusa/renderers/disk.py
+++ b/django_medusa/renderers/disk.py
@@ -36,7 +36,10 @@ def _disk_render_path(args):
 
         resp = client.get(path)
         if resp.status_code != 200:
-            raise Exception
+            raise Exception(
+                "Request to %s produced response code %d" %
+                (path, resp.status_code)
+            )
         if needs_ext:
             mime = resp['Content-Type']
             mime = mime.split(';', 1)[0]
@@ -69,7 +72,7 @@ class DiskStaticSiteRenderer(BaseStaticSiteRenderer):
             print("Generating with up to %d processes..." % cpu_count())
             pool = Pool(cpu_count())
 
-            pool.map_async(
+            pool.map(
                 _disk_render_path,
                 ((None, path, None) for path in self.paths),
                 chunksize=5

--- a/django_medusa/renderers/s3.py
+++ b/django_medusa/renderers/s3.py
@@ -71,7 +71,10 @@ def _s3_render_path(args):
     # Render the view
     resp = client.get(path)
     if resp.status_code != 200:
-        raise Exception
+        raise Exception(
+            "Request to %s produced response code %d" %
+            (path, resp.status_code)
+        )
 
     # Default to "index.html" as the upload path if we're in a dir listing.
     outpath = path


### PR DESCRIPTION
Adds a helpful message to the exception thrown in response to non-200 response codes. Additionally, prevents DiskStaticSiteRenderer from swallowing the exception when rendering paths in parallel.
